### PR TITLE
Configure client deployment to pull main image

### DIFF
--- a/kubernetes/manifests/dragonfly/client/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/client/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: ghcr.io/vipyrsec/dragonfly-client-rs:main
+          image: ghcr.io/vipyrsec/dragonfly-client-rs:edge
           imagePullPolicy: Always
           envFrom:
             - secretRef:


### PR DESCRIPTION
Configure the `deployment.yaml` manifest of the Dragonfly client to use the `:main` label, since the `rewrite` branch has since been merged into main.