### PR TITLE
Add deployment for Dragonfly reporter

### DIFF
--- a/kubernetes/manifests/dragonfly/reporter/README.md
+++ b/kubernetes/manifests/dragonfly/reporter/README.md
@@ -1,0 +1,11 @@
+# Dragonfly Reporter
+
+Infra configuration for the [Dragonfly Reporter](https://github.com/vipyrsec/dragonfly-reporter).
+
+## Secrets
+This deployment expects a number of secrets and environment variables to exist in a secret called `dragonfly-reporter-secrets`.
+
+
+| Environment             | Description                                 |
+|-------------------------|---------------------------------------------|
+| OBSERVATION_API_TOKEN   | The auth token for PyPI's Obeservations API |

--- a/kubernetes/manifests/dragonfly/reporter/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/reporter/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: dragonfly
+  name: reporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reporter
+  template:
+    metadata:
+      labels:
+        app: reporter
+    spec:
+      containers:
+        - name: reporter
+          image: ghcr.io/vipyrsec/dragonfly-reporter:edge
+          imagePullPolicy: Always
+          envFrom:
+            - secretRef:
+                name: dragonfly-reporter-env
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
+            readOnlyRootFilesystem: true

--- a/kubernetes/manifests/dragonfly/reporter/service.yaml
+++ b/kubernetes/manifests/dragonfly/reporter/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: dragonfly
+  name: reporter
+spec:
+  selector:
+    app: reporter
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
Setting up the initial deployment for https://github.com/vipyrsec/dragonfly-reporter.