### PR TITLE
Pin mainframe to `ec9fce9b`

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:5b2193b2f81d4b6c36d0c0d649da8683843f4053
+          image: ghcr.io/vipyrsec/bot:92e2b3332521860326c6dc6ca71f548fa0ce9fe2
           imagePullPolicy: Always
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:ccda8a122015739bdfee6203958d09a3e345e847
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:ec9fce9b3d4982e69eaee0aa96a465ce1a45ebd5
           imagePullPolicy: Always
           envFrom:
             - secretRef:


### PR DESCRIPTION
Also pins bot to `92e2b3332521860326c6dc6ca71f548fa0ce9fe2`

To deploy https://github.com/vipyrsec/dragonfly-mainframe/pull/291