### PR TITLE
Pin bot to `d4a84d6a4a792295048aadf57b48b3abe9aba9`

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:92e2b3332521860326c6dc6ca71f548fa0ce9fe2
+          image: ghcr.io/vipyrsec/bot:d4a84d6a4a792295048aadf57b48b3abe9aba953
           imagePullPolicy: Always
           envFrom:
             - secretRef:


### PR DESCRIPTION
Pin bot to an older commit because *some* people don't like the new look and are afraid of change.