### PR TITLE
fix(alloy): convert non-sensitive secret values to strings

### DIFF
--- a/kubernetes/chart/values/prod/vipyrsec.yaml
+++ b/kubernetes/chart/values/prod/vipyrsec.yaml
@@ -104,11 +104,11 @@ alloy:
         }
 
         prometheus.scrape "postgres_do" {
-        	targets    = [{"__address__" = remote.kubernetes.secret.postgres.data.metrics_url}]
+        	targets    = [{"__address__" = nonsensitive(remote.kubernetes.secret.postgres.data.metrics_url)}]
         	forward_to = [prometheus.relabel.tagged.receiver]
 
         	basic_auth {
-        		username = remote.kubernetes.secret.postgres.data.metrics_username
+        		username = nonsensitive(remote.kubernetes.secret.postgres.data.metrics_username)
         		password = remote.kubernetes.secret.postgres.data.metrics_password
         	}
         }

--- a/kubernetes/chart/values/staging/vipyrsec.yaml
+++ b/kubernetes/chart/values/staging/vipyrsec.yaml
@@ -104,11 +104,11 @@ alloy:
         }
 
         prometheus.scrape "postgres_do" {
-        	targets    = [{"__address__" = remote.kubernetes.secret.postgres.data.metrics_url}]
+        	targets    = [{"__address__" = nonsensitive(remote.kubernetes.secret.postgres.data.metrics_url)}]
         	forward_to = [prometheus.relabel.tagged.receiver]
 
         	basic_auth {
-        		username = remote.kubernetes.secret.postgres.data.metrics_username
+        		username = nonsensitive(remote.kubernetes.secret.postgres.data.metrics_username)
         		password = remote.kubernetes.secret.postgres.data.metrics_password
         	}
         }


### PR DESCRIPTION
We're using `Secret` data in places where Alloy expects strings, not secrets.
