### PR TITLE
ci: update `dependabot` configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,17 +6,31 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci
+    reviewers:
+      - vipyrsec/devops
+    assignees:
+      - vipyrsec/devops
 
   - package-ecosystem: docker
     directories:
-      - kubernetes/chart
-      - kubernetes/manifests/cert-manager
-      - kubernetes/manifests/discord
-      - kubernetes/manifests/discord/bot
-      - kubernetes/manifests/dragonfly
-      - kubernetes/manifests/dragonfly/client
-      - kubernetes/manifests/dragonfly/loader
-      - kubernetes/manifests/dragonfly/mainframe
-      - kubernetes/manifests/dragonfly/reporter
+      - kubernetes/chart/
+      - kubernetes/manifests/cert-manager/
+      - kubernetes/manifests/discord/
+      - kubernetes/manifests/discord/bot/
+      - kubernetes/manifests/dragonfly/
+      - kubernetes/manifests/dragonfly/client/
+      - kubernetes/manifests/dragonfly/loader/
+      - kubernetes/manifests/dragonfly/mainframe/
+      - kubernetes/manifests/dragonfly/reporter/
+      - kubernetes/manifests/monitoring/grafana/
+      - kubernetes/manifests/monitoring/prometheus/
     schedule:
       interval: monthly
+    commit-message:
+      prefix: deps
+    reviewers:
+      - vipyrsec/devops
+    assignees:
+      - vipyrsec/devops


### PR DESCRIPTION
This commit makes Dependabot assign PRs to DevOps.
Also, I've added the Grafana and Prometheus manifests to Dependabot's purview.
