### PR TITLE
ci: use the `helm` package ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,6 @@
 ---
 version: 2
+enable-beta-ecosystems: true
 
 updates:
   - package-ecosystem: github-actions
@@ -13,23 +14,33 @@ updates:
     assignees:
       - vipyrsec/devops
 
-  - package-ecosystem: docker
-    directories:
-      - kubernetes/chart/
-      - kubernetes/manifests/cert-manager/
-      - kubernetes/manifests/discord/
-      - kubernetes/manifests/discord/bot/
-      - kubernetes/manifests/dragonfly/
-      - kubernetes/manifests/dragonfly/client/
-      - kubernetes/manifests/dragonfly/loader/
-      - kubernetes/manifests/dragonfly/mainframe/
-      - kubernetes/manifests/dragonfly/reporter/
-      - kubernetes/manifests/monitoring/grafana/
-      - kubernetes/manifests/monitoring/prometheus/
+  - package-ecosystem: helm
+    directory: /kubernetes/chart/
     schedule:
       interval: monthly
     commit-message:
-      prefix: deps
+      prefix: deps(chart)
+    reviewers:
+      - vipyrsec/devops
+    assignees:
+      - vipyrsec/devops
+
+  - package-ecosystem: docker
+    directories:
+      - /kubernetes/manifests/cert-manager/
+      - /kubernetes/manifests/discord/
+      - /kubernetes/manifests/discord/bot/
+      - /kubernetes/manifests/dragonfly/
+      - /kubernetes/manifests/dragonfly/client/
+      - /kubernetes/manifests/dragonfly/loader/
+      - /kubernetes/manifests/dragonfly/mainframe/
+      - /kubernetes/manifests/dragonfly/reporter/
+      - /kubernetes/manifests/monitoring/grafana/
+      - /kubernetes/manifests/monitoring/prometheus/
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: deps(manifests)
     reviewers:
       - vipyrsec/devops
     assignees:


### PR DESCRIPTION
This resolves the issue with the `docker` Dependabot job…
![Issue with docker Dependabot job](https://github.com/user-attachments/assets/5f488399-70be-4979-8ec0-dd6f0ae2da47)
…while keeping the chart dependencies up-to-date.
![How the helm Dependabot job makes PRs](https://github.com/user-attachments/assets/034cd3b6-3e57-4f9f-9ada-5a4321efb9cd)