### PR TITLE
chore(staging/ingress-nginx): enable snippet annotations

### DIFF
--- a/kubernetes/chart/values/staging/vipyrsec.yaml
+++ b/kubernetes/chart/values/staging/vipyrsec.yaml
@@ -1,4 +1,10 @@
 ---
+ingress-nginx:
+  controller:
+    allowSnippetAnnotations: true
+    config:
+      annotations-risk-level: Critical
+
 alloy:
   enabled: true
 


### PR DESCRIPTION
The risk level is set to `Critical` because we use `server-snippet`.
