### PR TITLE
Deploy dragonfly-loader staging Cloudflare Access cutover

### DIFF
--- a/docs/dragonfly-loader-staging-cloudflare-access.md
+++ b/docs/dragonfly-loader-staging-cloudflare-access.md
@@ -1,0 +1,41 @@
+# Dragonfly Loader Staging Cloudflare Access
+
+This note records the direct staging secret rotation required to migrate
+`dragonfly-loader` from Auth0 to Cloudflare Access service-token headers.
+
+Applied on:
+
+- `2026-04-04`
+
+Staging Kubernetes secret:
+
+- `dragonfly/dragonfly-loader-env`
+
+Cloudflare Access token source:
+
+- token name: `dragonfly-loader-staging`
+- token id: `81f1ecf8-44b1-4636-9b13-a2ab077588d1`
+- created in Cloudflare account `Vipyr Security`
+- expires at: `2027-04-04T17:58:56Z`
+
+Secret contract after rotation:
+
+- `BASE_URL=https://dragonfly-staging.vipyrsec.com`
+- `CF_ACCESS_CLIENT_ID`
+- `CF_ACCESS_CLIENT_SECRET`
+
+Deprecated keys removed from the staging secret:
+
+- `AUTH0_DOMAIN`
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `USERNAME`
+- `PASSWORD`
+- `AUDIENCE`
+
+Notes:
+
+- Secret values are intentionally omitted from this file.
+- Cloudflare Access for `dragonfly-staging.vipyrsec.com` already had a
+  `non_identity` policy allowing `any_valid_service_token` at the time of
+  rotation.

--- a/kubernetes/manifests/dragonfly/loader/README.md
+++ b/kubernetes/manifests/dragonfly/loader/README.md
@@ -10,9 +10,8 @@ This deployment expects a number of secrets and environment variables to exist i
 | Environment   | Description                               |
 | ------------- | ----------------------------------------- |
 | BASE_URL      | Base URL of the Dragonfly API             |
-| AUTH0_DOMAIN  | Domain of the AUTH0 authentication server |
-| CLIENT_ID     | Client ID                                 |
-| CLIENT_SECRET | Client secret                             |
-| USERNAME      | Username                                  |
-| PASSWORD      | Password                                  |
-| AUDIENCE      | Authentication audience                   |
+| CF_ACCESS_CLIENT_ID | Cloudflare Access service token client ID |
+| CF_ACCESS_CLIENT_SECRET | Cloudflare Access service token client secret |
+
+For staging, `BASE_URL` should be the public protected hostname
+`https://dragonfly-staging.vipyrsec.com`.

--- a/kubernetes/manifests/dragonfly/loader/cronjob.yaml
+++ b/kubernetes/manifests/dragonfly/loader/cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: dragonfly-loader
-              image: ghcr.io/vipyrsec/dragonfly-loader:sha-fc9128434c0f15b90e7f0ec686bd1932f3c5fd4a
+              image: ghcr.io/vipyrsec/dragonfly-loader:sha-9f67b5bfcab22089deef147902532c3c9f17d90b
               imagePullPolicy: IfNotPresent
               envFrom:
                 - secretRef:


### PR DESCRIPTION
## Summary
- bump the staging `dragonfly-loader` CronJob to the merged Cloudflare Access image
- update the loader infra docs from the old Auth0 contract to the Cloudflare Access service-token contract
- record the staging Cloudflare Access token rotation without storing secret values in git

## Validation
- confirmed `dragonfly-loader` image `sha-9f67b5bfcab22089deef147902532c3c9f17d90b` was published from `main`
- updated `dragonfly-loader-env` in `do-sfo3-staging` to `BASE_URL`, `CF_ACCESS_CLIENT_ID`, and `CF_ACCESS_CLIENT_SECRET`
- applied the updated CronJob manifest in staging
- ran `kubectl --context do-sfo3-staging -n dragonfly create job --from=cronjob/dragonfly-loader dragonfly-loader-manual-20260404-1802`
- verified `job/dragonfly-loader-manual-20260404-1802` completed successfully
