### PR TITLE
Restore Dragonfly loader scheduling

### DIFF
--- a/.github/workflows/bash-ci.yaml
+++ b/.github/workflows/bash-ci.yaml
@@ -7,6 +7,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: ShellCheck
@@ -14,8 +21,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # master
         env:
           SHELLCHECK_OPTS: -e SC2028

--- a/.github/workflows/kubernetes-ci.yaml
+++ b/.github/workflows/kubernetes-ci.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -28,6 +31,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
@@ -38,7 +43,9 @@ jobs:
         run: go install -ldflags='-s -w' -race -trimpath sigs.k8s.io/kubectl-validate@latest
 
       - name: Lint manifests
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
         run: |-
           kubectl-validate kubernetes/manifests/ \
             --local-crds kubernetes/crds/ \
-            --version '${{ matrix.kubernetes-version }}'
+            --version "${KUBERNETES_VERSION}"

--- a/kubernetes/manifests/dragonfly/loader/cronjob.yaml
+++ b/kubernetes/manifests/dragonfly/loader/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   jobTemplate:
     spec:
       activeDeadlineSeconds: 120
+      backoffLimit: 0
       template:
         spec:
           containers:

--- a/kubernetes/manifests/dragonfly/loader/cronjob.yaml
+++ b/kubernetes/manifests/dragonfly/loader/cronjob.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   schedule: '* * * * *'
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 120
       template:
         spec:
           containers:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-be6a87f9ae471bc738eadacfa8017544e5c6cb70
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-2e12201604066ccb1780aaddc16dfc4face6654d
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- prevent a stuck loader Job from blocking future CronJob schedules indefinitely
- let the per-minute CronJob provide retries instead of spawning up to seven pods for one failed run
- promote the mainframe image containing the regression-tested PyPI JSON compatibility fix
- harden the touched GitHub Actions workflows so `zizmor --pedantic` passes

## Incident

The production loader Job became stuck when its node's `/run` tmpfs filled during Cilium CNI log rotation. Because the CronJob uses `concurrencyPolicy: Forbid`, every later schedule was skipped.

Staging independently exposed the application-level failure that would have blocked recovery: its older mainframe image rejected PyPI's `core-metadata` JSON field and returned HTTP 500 from `/batch/package`.

## Staging validation

- promoted staging mainframe to `sha-2e12201604066ccb1780aaddc16dfc4face6654d`
- observed the existing failed loader Job retry successfully
- observed subsequent scheduled loader Jobs complete successfully
- observed the scanner begin processing newly queued packages
- applied and verified `startingDeadlineSeconds: 120`, `activeDeadlineSeconds: 120`, and `backoffLimit: 0`
- confirmed both staging nodes have healthy `/run` headroom (8–9% used)

Production has not been modified.

## Checks

- `kubectl-validate kubernetes/manifests --version 1.30.0`
- pinned `prek` changed-file hooks
- `yamllint --strict`
- `zizmor --pedantic .github/workflows`
- `git diff --check`
