### PR TITLE
Pin Cloudflare migration images

### DIFF
--- a/docs/cloudflare-access-migration.md
+++ b/docs/cloudflare-access-migration.md
@@ -61,6 +61,15 @@ Rotate the Cloudflare client certificate and cluster CA together before expiry,
 staging first. Keep the old CA in the verification bundle during a planned
 overlap if zero-downtime rotation is required.
 
+After every upload, verify that Cloudflare's
+`hostname_aop_custom_certificate_expiration_type` notification policy is
+enabled and has the intended recipients. Treat that native notification as the
+authoritative pre-expiry alert because Cloudflare stores the client
+certificate. Also monitor `ca.crt` expiry in both Kubernetes Secrets as a drift
+check. Use an external authenticated availability probe for each hostname:
+an AOP handshake failure occurs before a request reaches mainframe, so Sentry
+alone cannot detect an expired or mismatched client certificate.
+
 ## Pre-cutover evidence handling
 
 Keep the environment inventory and validation evidence in the private change

--- a/docs/cloudflare-access-migration.md
+++ b/docs/cloudflare-access-migration.md
@@ -13,6 +13,10 @@ The following rules are mandatory:
 - policies select named service tokens; `any valid service token` is forbidden
 - callers use the public Cloudflare-protected hostname, never a forwarded or
   directly enumerable origin
+- public load balancers accept only Cloudflare's published origin-facing
+  networks
+- each hostname uses a separate custom Authenticated Origin Pulls certificate;
+  the shared global Cloudflare certificate is insufficient
 - Kubernetes Secret values remain cluster-local and are never committed
 - application and infrastructure PRs are approved before either environment is
   changed
@@ -31,7 +35,31 @@ The following rules are mandatory:
 
 The Cloudflare team domain is tenant-wide and may be the same in both
 environments. Application audiences, service-token IDs, service-token secrets,
-and Kubernetes Secret values must be different.
+Authenticated Origin Pulls certificates, and Kubernetes Secret values must be
+different.
+
+## Origin authentication
+
+Cloudflare Access authenticates users and machine callers at the edge, while
+mainframe validates the resulting assertion. The origin also requires two
+independent network controls:
+
+1. `ingress-nginx`'s public load balancer uses
+   `loadBalancerSourceRanges` containing Cloudflare's published IPv4 ranges.
+2. The Dragonfly Ingress requires a client certificate signed by the
+   environment-specific `dragonfly/cloudflare-aop-ca` Secret.
+
+Configure per-hostname Authenticated Origin Pulls with a custom certificate for
+each public API hostname. Do not use Cloudflare's shared global AOP certificate:
+it proves only that a request came from Cloudflare's network, not from this
+account. Upload only the matching leaf certificate and private key to
+Cloudflare. Store only the issuing CA's public certificate in the cluster
+Secret as `ca.crt`; do not commit any certificate private key.
+
+Record the certificate identifier and expiry in the private change record.
+Rotate the Cloudflare client certificate and cluster CA together before expiry,
+staging first. Keep the old CA in the verification bundle during a planned
+overlap if zero-downtime rotation is required.
 
 ## Pre-cutover evidence handling
 
@@ -148,21 +176,25 @@ Before changing staging:
 1. Confirm `doctl` context `vipyr` and Kubernetes context
    `do-sfo3-staging`.
 2. Create or reconcile the staging Access application and named policies.
-3. Create staging-only service tokens and write them directly to the matching
+3. Create the staging-only AOP certificate and `cloudflare-aop-ca` Secret,
+   enable its hostname association, and verify the association is active.
+4. Create staging-only service tokens and write them directly to the matching
    staging Kubernetes Secrets.
-4. Set the staging mainframe audience and team domain.
-5. Apply reviewed manifests and immutable application images.
-6. Wait for rollouts and the next loader CronJob; do not start duplicate Jobs.
-7. Exercise all nine protected routes:
+5. Set the staging mainframe audience and team domain.
+6. Apply reviewed manifests and immutable application images.
+7. Wait for rollouts and the next loader CronJob; do not start duplicate Jobs.
+8. Confirm a valid caller crosses AOP and direct-origin requests without the
+   environment-specific client certificate fail.
+9. Exercise all nine protected routes:
    - unauthenticated requests are rejected
    - legacy bearer requests are rejected
    - invalid assertions are rejected
    - valid human or service-token requests reach the application
-8. Confirm loader `POST /batch/package`, scanner `GET /rules`, scanner
+10. Confirm loader `POST /batch/package`, scanner `GET /rules`, scanner
    `POST /jobs`, scanner `PUT /package`, and all three bot routes succeed.
-9. Confirm application logs and Sentry contain no authentication regression,
+11. Confirm application logs and Sentry contain no authentication regression,
    crash loop, or unexpected origin traffic.
-10. Observe at least two scheduled loader executions with no overlapping or
+12. Observe at least two scheduled loader executions with no overlapping or
     stuck Job.
 
 ## Production rollout
@@ -170,16 +202,18 @@ Before changing staging:
 Production begins only after staging passes and its evidence is recorded.
 
 1. Confirm `doctl` context `vipyr` and Kubernetes context `do-sfo3-prod`.
-2. Create the production Access application, named policies, and production-only
+2. Create the production-only AOP certificate and `cloudflare-aop-ca` Secret,
+   enable its hostname association, and verify the association is active.
+3. Create the production Access application, named policies, and production-only
    service tokens.
-3. Write production values directly to production Kubernetes Secrets and the
+4. Write production values directly to production Kubernetes Secrets and the
    `dragonfly-production` GitHub environment.
-4. Apply the same reviewed manifest revision and application commits proven in
+5. Apply the same reviewed manifest revision and application commits proven in
    staging.
-5. Repeat the complete route and caller validation matrix.
-6. Confirm the loader schedule, scanner queue depth, result submissions,
+6. Repeat the AOP, direct-origin, complete route, and caller validation matrix.
+7. Confirm the loader schedule, scanner queue depth, result submissions,
    security-intelligence rule update, logs, and Sentry.
-7. Compare staging and production manifests, Secret key names, Access policy
+8. Compare staging and production manifests, Secret key names, Access policy
    shapes, and image commits. Only environment-specific hostnames, audiences,
    token identities, and secret values may differ.
 

--- a/kubernetes/chart/values/prod/vipyrsec.yaml
+++ b/kubernetes/chart/values/prod/vipyrsec.yaml
@@ -4,6 +4,25 @@ ingress-nginx:
     allowSnippetAnnotations: true
     config:
       annotations-risk-level: Critical
+    service:
+      # The public origin must only accept traffic from Cloudflare's edge.
+      # Source: https://www.cloudflare.com/ips-v4
+      loadBalancerSourceRanges:
+        - 173.245.48.0/20
+        - 103.21.244.0/22
+        - 103.22.200.0/22
+        - 103.31.4.0/22
+        - 141.101.64.0/18
+        - 108.162.192.0/18
+        - 190.93.240.0/20
+        - 188.114.96.0/20
+        - 197.234.240.0/22
+        - 198.41.128.0/17
+        - 162.158.0.0/15
+        - 104.16.0.0/13
+        - 104.24.0.0/14
+        - 172.64.0.0/13
+        - 131.0.72.0/22
 
 alloy:
   enabled: true

--- a/kubernetes/chart/values/staging/vipyrsec.yaml
+++ b/kubernetes/chart/values/staging/vipyrsec.yaml
@@ -4,6 +4,25 @@ ingress-nginx:
     allowSnippetAnnotations: true
     config:
       annotations-risk-level: Critical
+    service:
+      # The public origin must only accept traffic from Cloudflare's edge.
+      # Source: https://www.cloudflare.com/ips-v4
+      loadBalancerSourceRanges:
+        - 173.245.48.0/20
+        - 103.21.244.0/22
+        - 103.22.200.0/22
+        - 103.31.4.0/22
+        - 141.101.64.0/18
+        - 108.162.192.0/18
+        - 190.93.240.0/20
+        - 188.114.96.0/20
+        - 197.234.240.0/22
+        - 198.41.128.0/17
+        - 162.158.0.0/15
+        - 104.16.0.0/13
+        - 104.24.0.0/14
+        - 172.64.0.0/13
+        - 131.0.72.0/22
 
 alloy:
   enabled: true

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-17a31af8f2ad5141c3edd8460c4b10a04b0decf7
+          image: ghcr.io/vipyrsec/bot:sha-bdf56bf09c9dcda49f6cfbb7ac7d7454743c24ea
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-bdf56bf09c9dcda49f6cfbb7ac7d7454743c24ea
+          image: ghcr.io/vipyrsec/bot:sha-18f878aedbb99f5570f1c2e5b7c4d28e3fff42af
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/client/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/client/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: ghcr.io/vipyrsec/dragonfly-client-rs:sha-e68fa03ba254496667f3b9fe2a0f1c0c3c54185b
+          image: ghcr.io/vipyrsec/dragonfly-client-rs:sha-0aa7b46e8431686205fcb3dec0a943e3e60a38d3
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/loader/cronjob.yaml
+++ b/kubernetes/manifests/dragonfly/loader/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: dragonfly-loader
-              image: ghcr.io/vipyrsec/dragonfly-loader:sha-fc9128434c0f15b90e7f0ec686bd1932f3c5fd4a
+              image: ghcr.io/vipyrsec/dragonfly-loader:sha-7acd34813cc2c74e0c4849b1b6c2a1c5fc651beb
               imagePullPolicy: IfNotPresent
               envFrom:
                 - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/README.md
+++ b/kubernetes/manifests/dragonfly/mainframe/README.md
@@ -22,3 +22,9 @@ Staging and production must use different Access application audiences.
 `CF_ACCESS_TEAM_DOMAIN` may be shared because both applications belong to the
 same Cloudflare Zero Trust tenant; application audiences and caller service
 tokens must not be shared.
+
+The Ingress also expects `dragonfly/cloudflare-aop-ca` with a `ca.crt` key.
+This public CA verifies the environment-specific Cloudflare Authenticated
+Origin Pulls client certificate. Staging and production must use different
+certificate authorities; no CA private key or client private key belongs in
+this repository or cluster Secret.

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-2e12201604066ccb1780aaddc16dfc4face6654d
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-5b33d698d1c27d93149fd2f093ec44e512ee7a5f
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/ingress.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   name: dragonfly-ingress
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/auth-tls-secret: dragonfly/cloudflare-aop-ca
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: 'on'
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: '1'
     nginx.ingress.kubernetes.io/server-snippet: |
       location /metrics {
         deny all;


### PR DESCRIPTION
## Summary

- pin the reviewed Dragonfly application images
- keep every workload on an immutable `sha-*` image
- add the reviewed Cloudflare origin controls for staging and production
- document environment separation, certificate rotation, and monitoring

## Validation

- Kubernetes 1.30 manifest validation
- staging and production Helm rendering
- repository-wide pre-commit hooks
- pedantic GitHub Actions audit
- CodeQL and Socket checks
- staging route, caller, scheduler, and stability validation

## Rollout

Staging was validated before production work began. Production remains
intentionally unchanged for the new origin-authentication control until this
revision is merged. No credentials, tenant identifiers, certificate
identifiers, application audiences, or private runtime inventory are stored in
this public repository.
