### PR TITLE
Deploy bot e5134e2 to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-18f878aedbb99f5570f1c2e5b7c4d28e3fff42af
+          image: ghcr.io/vipyrsec/bot:sha-e5134e2304a869726d43ffa4ff339787102b8483
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy the bot image built from `vipyrsec/bot` main commit `e5134e2304a869726d43ffa4ff339787102b8483`
- bring PRs `vipyrsec/bot#290` and `vipyrsec/bot#308` to staging for testing

## Validation

- `prek run --all-files`
- `zizmor --pedantic .github/workflows`
- `kubectl --context do-sfo3-staging apply --dry-run=client -f kubernetes/manifests/discord/bot/deployment.yaml`
- upstream image build, signing, and manifest publication succeeded
