### PR TITLE
Deploy bot e4b1e3d to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-e5134e2304a869726d43ffa4ff339787102b8483
+          image: ghcr.io/vipyrsec/bot:sha-e4b1e3d101e0fec5817aa3ec1b0a3d27a4cc9a44
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy the bot image built from `vipyrsec/bot` main commit `e4b1e3d101e0fec5817aa3ec1b0a3d27a4cc9a44`
- roll out `/rdap` interaction support and RDAP timeout/enrichment hardening to staging

## Validation

- `prek run --all-files`
- `zizmor --pedantic .github/workflows`
- `kubectl --context do-sfo3-staging apply --dry-run=client -f kubernetes/manifests/discord/bot/deployment.yaml`
- upstream image build, signing, and manifest publication succeeded
