### PR TITLE
Deploy bot 891a00c to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-e4b1e3d101e0fec5817aa3ec1b0a3d27a4cc9a44
+          image: ghcr.io/vipyrsec/bot:sha-891a00c67902615cb117db6b8bf3384316bbdfb9
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy bot main commit `891a00c67902615cb117db6b8bf3384316bbdfb9` to staging
- stop repeated Threat Intelligence Feed authentication retries after permanent GitHub 401/404 responses
- retain retries for potentially transient GitHub 403 responses

## Validation

- `prek run --all-files`
- `zizmor --pedantic .github/workflows`
- `kubectl --context do-sfo3-staging apply --dry-run=client -f kubernetes/manifests/discord/bot/deployment.yaml`
- bot image build, signing, and manifest publication succeeded on `main`
