### PR TITLE
Document Dragonfly queue observability rollout

### DIFF
--- a/docs/dragonfly-queue-observability.md
+++ b/docs/dragonfly-queue-observability.md
@@ -1,0 +1,102 @@
+# Dragonfly queue observability
+
+Mainframe reconciles its queue gauges from PostgreSQL once every 60 seconds by
+default. Each replica performs one aggregate query per interval. Prometheus scrapes
+and the environment's bot `/queue-status` invocations read the process-local
+snapshot and do not issue database queries.
+
+The aggregate is restricted to `QUEUED` and `PENDING` rows so PostgreSQL can use the
+existing partial `scans.status` index. Keep `QUEUE_METRICS_REFRESH_SECONDS=60` in
+staging and production unless a measured operational requirement justifies a
+shorter interval.
+
+## Grafana queries
+
+Use these expressions in the existing Dragonfly staging-versus-production
+dashboard. Retain the dashboard's `$cluster` selector.
+
+Queue states over time:
+
+```promql
+max by (cluster, state) (
+  packages_queue{cluster=~"$cluster", namespace="dragonfly", container="mainframe"}
+)
+```
+
+Runnable backlog, excluding scans actively leased to a client:
+
+```promql
+sum by (cluster) (
+  packages_queue{
+    cluster=~"$cluster",
+    namespace="dragonfly",
+    container="mainframe",
+    state=~"queued|retryable"
+  }
+)
+```
+
+The `stranded` state identifies invalid `PENDING` rows with no lease timestamp.
+Workers cannot reclaim those rows, so they are visible as pressure but excluded
+from runnable backlog.
+
+Oldest runnable package age:
+
+```promql
+max by (cluster) (
+  packages_queue_oldest_age_seconds{
+    cluster=~"$cluster",
+    namespace="dragonfly",
+    container="mainframe"
+  }
+)
+```
+
+Snapshot staleness:
+
+```promql
+time() - max by (cluster) (
+  packages_queue_snapshot_timestamp_seconds{
+    cluster=~"$cluster",
+    namespace="dragonfly",
+    container="mainframe"
+  }
+)
+```
+
+Refresh failures:
+
+```promql
+sum by (cluster) (
+  increase(packages_queue_refresh_failures_total{
+    cluster=~"$cluster",
+    namespace="dragonfly",
+    container="mainframe"
+  }[15m])
+)
+```
+
+Compare these panels with the existing `packages_ingested_total`,
+`packages_success_total`, and `packages_fail_total` rates to distinguish bursty
+normal traffic from a stalled consumer.
+
+## Staging flight
+
+1. Deploy Mainframe to staging with the default 60-second refresh.
+2. Confirm `packages_queue_snapshot_timestamp_seconds` advances once per minute.
+3. Confirm snapshot staleness remains below 120 seconds and refresh failures remain
+   zero.
+4. Confirm the staging bot's existing `DRAGONFLY_API_URL` and Cloudflare Access
+   service token target only staging.
+5. Deploy the staging bot and verify `/queue-status` shows the staging queue only.
+6. Observe database CPU, read IOPS, and query latency for at least one normal
+   traffic window before promoting Mainframe to production.
+
+If a refresh fails, Mainframe retains its last successful snapshot and increments
+the failure counter. If a Mainframe pod is killed, Kubernetes recreates it according
+to the Deployment; `/queue-status` is unavailable only until the replacement
+process obtains its initial successful snapshot.
+
+Repeat the same checks for the production bot after promotion. Production uses its
+own `DRAGONFLY_API_URL` and Cloudflare Access service token and reports only the
+production queue.

--- a/kubernetes/manifests/discord/bot/README.md
+++ b/kubernetes/manifests/discord/bot/README.md
@@ -16,3 +16,5 @@ This deployment expects a number of secrets and environment variables to exist i
 | CF_ACCESS_CLIENT_SECRET | Environment-specific Cloudflare Access service-token secret  |
 
 Staging and production must use separate service tokens and API URLs.
+Each bot reads the cached `/queue-status` endpoint from its own
+`DRAGONFLY_API_URL`, so bot commands do not query PostgreSQL.

--- a/kubernetes/manifests/dragonfly/mainframe/README.md
+++ b/kubernetes/manifests/dragonfly/mainframe/README.md
@@ -7,16 +7,17 @@ Infra configuration for the [Dragonfly Mainframe](https://github.com/vipyrsec/dr
 This deployment expects its environment variables to exist in a secret called
 `dragonfly-mainframe-env`.
 
-| Environment             | Description                                              |
-| ----------------------- | -------------------------------------------------------- |
-| CF_ACCESS_AUDIENCE      | Audience of this environment's Cloudflare Access app     |
-| CF_ACCESS_TEAM_DOMAIN   | Cloudflare Access team-domain issuer                     |
-| DB_URL                  | The database connection DSN                              |
-| DRAGONFLY_GITHUB_TOKEN  | A GitHub PAT to access the Security Intelligence ruleset |
-| EMAIL_RECIPIENT         | The default email recipient                              |
-| MICROSOFT_TENANT_ID     | Part of the credentials for the mailer                   |
-| MICROSOFT_CLIENT_ID     | Part of the credentials for the mailer                   |
-| MICROSOFT_CLIENT_SECRET | Part of the credentials for the mailer                   |
+| Environment                   | Description                                              |
+| ----------------------------- | -------------------------------------------------------- |
+| CF_ACCESS_AUDIENCE            | Audience of this environment's Cloudflare Access app     |
+| CF_ACCESS_TEAM_DOMAIN         | Cloudflare Access team-domain issuer                     |
+| DB_URL                        | The database connection DSN                              |
+| DRAGONFLY_GITHUB_TOKEN        | A GitHub PAT to access the Security Intelligence ruleset |
+| QUEUE_METRICS_REFRESH_SECONDS | Seconds between queue snapshots (default: `60`)          |
+| EMAIL_RECIPIENT               | The default email recipient                              |
+| MICROSOFT_TENANT_ID           | Part of the credentials for the mailer                   |
+| MICROSOFT_CLIENT_ID           | Part of the credentials for the mailer                   |
+| MICROSOFT_CLIENT_SECRET       | Part of the credentials for the mailer                   |
 
 Staging and production must use different Access application audiences.
 `CF_ACCESS_TEAM_DOMAIN` may be shared because both applications belong to the
@@ -28,3 +29,7 @@ This public CA verifies the environment-specific Cloudflare Authenticated
 Origin Pulls client certificate. Staging and production must use different
 certificate authorities; no CA private key or client private key belongs in
 this repository or cluster Secret.
+
+Each queue snapshot performs one aggregate PostgreSQL query restricted to queued
+and pending rows. Prometheus scrapes and `/queue-status` requests use the cached
+snapshot and do not query PostgreSQL.


### PR DESCRIPTION
## What changed

- document the 60-second database reconciliation contract
- document that each bot reports only its environment-local Dragonfly queue
- provide PromQL for queue states, runnable backlog, oldest age, snapshot staleness,
  and refresh failures
- document stranded pending rows separately from runnable backlog
- add a staging-to-production flight checklist

## Why

The changes in vipyrsec/dragonfly-mainframe#397 and vipyrsec/bot#323 need an
auditable rollout path. This documentation makes the database query budget,
environment isolation, monitoring checks, and failure behavior explicit without
committing any secret values.

## Validation

- all repository pre-commit hooks
- markdownlint
- yamllint and yamlfix
- ripsecrets
- zizmor: no findings
