### PR TITLE
Deploy queue observability to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-891a00c67902615cb117db6b8bf3384316bbdfb9
+          image: ghcr.io/vipyrsec/bot:sha-1729c24eca2ad85081de3bf4932e625a293d7d36
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-5b33d698d1c27d93149fd2f093ec44e512ee7a5f
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-9da755602f857d4bdd548806ef5ae0ce9bf49fe7
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## What changed

- pin staging Mainframe to merge commit `9da755602f857d4bdd548806ef5ae0ce9bf49fe7`
- pin staging bot to merge commit `1729c24eca2ad85081de3bf4932e625a293d7d36`

## Why

This flights the cached queue observability endpoint and the environment-local
Discord queue-status command to staging. Production is not being modified.

## Validation

- both image publication workflows completed successfully and signed the images
- all infrastructure pre-commit hooks passed
- zizmor reported no findings
- current staging Mainframe and bot deployments were healthy before rollout
