### PR TITLE
Deploy queue timestamp hotfix to staging

### DIFF
--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-9da755602f857d4bdd548806ef5ae0ce9bf49fe7
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-929d87dcfdf6575b04215f73f3e4adebc039fdf4
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- pin staging Mainframe to the signed image built from `vipyrsec/dragonfly-mainframe@929d87dcfdf6575b04215f73f3e4adebc039fdf4`
- deploy the UTC normalization fix for legacy queue timestamps
- leave the staging bot and every production workload unchanged

## Source

- https://github.com/vipyrsec/dragonfly-mainframe/pull/398
- image workflow: https://github.com/vipyrsec/dragonfly-mainframe/actions/runs/30139897194

## Validation

- Kubernetes server-side dry run passed against `do-sfo3-staging`
- all pinned pre-commit hooks passed
- source PR passed 152 tests at 100% coverage, Ruff, pyright, CodeQL, Socket, and Greptile

## Rollout

After merge, apply only `kubernetes/manifests/dragonfly/mainframe/deployment.yaml` to `do-sfo3-staging`, await rollout, and verify two successive queue metric refreshes plus pod logs, restarts, and events.
