### PR TITLE
Deploy rule metrics to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-1729c24eca2ad85081de3bf4932e625a293d7d36
+          image: ghcr.io/vipyrsec/bot:sha-b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-929d87dcfdf6575b04215f73f3e4adebc039fdf4
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- pin staging Mainframe to the merged rule-metrics and durable alert-configuration release
- pin the staging Discord bot to the merged Mainframe-backed alert-configuration release

## Validation

- deployed both images to `do-sfo3-staging`
- Mainframe migration advanced to `f6c1e85d4a29 (head)`
- verified `/public/statistics` returns 200 without rule details
- verified `/metrics` returns 200 with rule metrics
- verified unauthenticated `/rules/performance` returns 401
- observed consecutive bot `/alerting/configuration` requests returning 200
- both new pods are running with zero restarts
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
