### PR TITLE
Align staging image pins with production

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7
+          image: ghcr.io/vipyrsec/bot:sha-891a00c67902615cb117db6b8bf3384316bbdfb9
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-5b33d698d1c27d93149fd2f093ec44e512ee7a5f
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- align the staging Discord bot image pin with the image currently running in production
- align the staging Dragonfly mainframe image pin with the image currently running in production
- leave the Kubernetes Dragonfly client pin unchanged because that deployment is being retired in favor of the App Platform scanner

## Impact

This intentionally rolls staging back to the production baseline:

- bot: `b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7` to `891a00c67902615cb117db6b8bf3384316bbdfb9`
- mainframe: `f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46` to `5b33d698d1c27d93149fd2f093ec44e512ee7a5f`

The staging-only commits being removed include queue observability, persistent rule-performance metrics, mainframe-managed bot alert thresholds, and later Cloudflare JWT validation hardening. Production behavior is unchanged because it already runs the target pins.

The Kubernetes scanner remains pinned to `0aa7b46e8431686205fcb3dec0a943e3e60a38d3`; this change does not upgrade or restart it intentionally.

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- `kubectl --context do-sfo3-staging apply --dry-run=server` for both changed deployments
- verified the live production pins and upstream commit provenance
- verified the Dragonfly client manifest has no diff
