### PR TITLE
Restore staging pins for production promotion

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-891a00c67902615cb117db6b8bf3384316bbdfb9
+          image: ghcr.io/vipyrsec/bot:sha-b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-5b33d698d1c27d93149fd2f093ec44e512ee7a5f
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- restore the infrastructure source of truth to the image pins validated in staging
- make those pins the production promotion targets
- leave the Kubernetes Dragonfly client pin unchanged because that deployment is being retired

## Corrected direction

- bot: `891a00c67902615cb117db6b8bf3384316bbdfb9` to `b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7`
- mainframe: `5b33d698d1c27d93149fd2f093ec44e512ee7a5f` to `f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46`

These are forward promotions for production. The mainframe must be deployed and verified before the bot.

## Incident correction

PR #170 reversed the intended direction and temporarily rolled staging back to the production pins. The older mainframe could not start against staging's newer Alembic revision `f6c1e85d4a29`. Staging was immediately restored to the pins in this PR and both workloads are healthy.

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- server-side dry runs against `do-sfo3-staging` and `do-sfo3-prod`
- verified staging recovery on the target pins with ready replicas and zero restarts
- verified the Dragonfly client manifest has no diff
