### PR TITLE
Deploy suppressions to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-b86e5c6adbcd083b0e0decb8ad1ac55e9d1639e7
+          image: ghcr.io/vipyrsec/bot:sha-448e71f0ad348023340194fb5a8316d4ae8a93fc
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-f8da8b4adcbca3a6edab5e572e4a6d1ffbde8a46
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-0890d227a280cd0b270692f81e3e1f3c18203c1f
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- pin staging Mainframe to merge commit `0890d227a280cd0b270692f81e3e1f3c18203c1f`
- pin staging Bot to merge commit `448e71f0ad348023340194fb5a8316d4ae8a93fc`

## Why

Deploy the package-version suppression API and its dependent Bot alert controls to staging using signed, immutable images produced from the merged main branches.

Mainframe will roll out first so its startup migration creates the suppression table before Bot begins consuming the API.

## Impact

The staging Mainframe and Bot deployments each roll once. No configuration, secret, service, ingress, replica, or production resources change.

## Validation

- both main-branch image build/sign/publish workflows passed
- changed-file audited `prek` hooks passed
- Kubernetes client-side dry run passed
- staging server-side diff contains only the two intended image substitutions

The repository-wide hook suite remains blocked by an unrelated pre-existing `yamlfix`/`yamllint` conflict in `kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml`; this PR does not modify that file.
