### PR TITLE
Deploy package-wide suppressions to staging

### DIFF
--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-448e71f0ad348023340194fb5a8316d4ae8a93fc
+          image: ghcr.io/vipyrsec/bot:sha-f04d93f7d4153555a0aa6f8b8f508df135ef52c0
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy Bot image `sha-f04d93f7d4153555a0aa6f8b8f508df135ef52c0` to staging
- include native suppression slash commands and package-wide tuned rule evaluation

## Source changes

- vipyrsec/bot#327
- vipyrsec/bot#328

The image was built, signed, and published by the Bot repository's main-branch image workflow.

## Validation

- changed-file audited hooks passed
- `kubectl apply --dry-run=client` passed against `do-sfo3-staging`
- `kubectl diff` showed only the Bot image substitution

The complete infrastructure hook suite also ran. Its only failures are the existing `yamlfix`/`yamllint` conflict in `kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml`; hook-generated changes to that unrelated file were discarded, and this PR remains a one-line image pin.
