### PR TITLE
Scale Kubernetes Dragonfly clients to zero

### DIFF
--- a/kubernetes/manifests/dragonfly/client/README.md
+++ b/kubernetes/manifests/dragonfly/client/README.md
@@ -3,6 +3,9 @@
 Infra configuration for the Dragonfly client. We're currently using the
 [Dragonfly Rust client](https://github.com/vipyrsec/dragonfly-client-rs).
 
+The Kubernetes deployment is scaled to zero in staging and production because
+the active scanners run on DigitalOcean App Platform.
+
 ## Secrets
 
 This deployment expects its environment variables to exist in a secret called

--- a/kubernetes/manifests/dragonfly/client/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/client/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: client
 
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: client


### PR DESCRIPTION
## Summary

- scale the shared Dragonfly Kubernetes client deployment to zero replicas in staging and production
- document DigitalOcean App Platform as the active scanner runtime

## Why

The staging and production scanners now run on DigitalOcean App Platform. Keeping
the duplicate Kubernetes client active consumes scarce node memory and creates
an unnecessary second scanner runtime.

This change preserves the Kubernetes deployment definition as a documented
fallback while removing its runtime resource consumption.

## Impact

Applying the shared manifest to staging and production will terminate the
Kubernetes-hosted Dragonfly client pods. App Platform scanners remain active in
both environments.

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --files kubernetes/manifests/dragonfly/client/deployment.yaml kubernetes/manifests/dragonfly/client/README.md`
- `/home/rem/go/bin/kubectl-validate kubernetes/manifests/dragonfly/client/deployment.yaml --local-crds kubernetes/crds/ --version 1.30`
- `zizmor --pedantic .github/workflows/`
- `git diff --check`

The repository-wide hook run also exposed an unrelated pre-existing formatting
conflict in `kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml`;
that file is intentionally excluded from this PR.
