### PR TITLE
Deploy Mainframe dead-letter handling to staging

### DIFF
--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-0890d227a280cd0b270692f81e3e1f3c18203c1f
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-d25c0b077d23d09016667a0942e2ac67dbb33cd0
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy the Mainframe dead-letter and bounded-retry release to staging
- update only the staging Mainframe image to the image built from merged Mainframe PR 404

## Validation

- `kubectl config current-context` → `do-sfo3-staging`
- `kubectl diff -f kubernetes/manifests/dragonfly/mainframe/deployment.yaml` showed only the intended image update (plus server-managed metadata)
- `prek run yamlfix --files kubernetes/manifests/dragonfly/mainframe/deployment.yaml`
- `prek run yamllint --files kubernetes/manifests/dragonfly/mainframe/deployment.yaml`
- `prek run ripsecrets --files kubernetes/manifests/dragonfly/mainframe/deployment.yaml`

The full repository hook suite also found a pre-existing, unrelated formatting/line-length conflict in `kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml`; no unrelated hook edits are included in this PR.

## Source release

- Mainframe PR: https://github.com/vipyrsec/dragonfly-mainframe/pull/404
- Mainframe merge commit: `d25c0b077d23d09016667a0942e2ac67dbb33cd0`
- Image: `ghcr.io/vipyrsec/dragonfly-mainframe:sha-d25c0b077d23d09016667a0942e2ac67dbb33cd0`
