### PR TITLE
Provision staging Grafana alerts

### DIFF
--- a/kubernetes/manifests/monitoring/grafana/README.md
+++ b/kubernetes/manifests/monitoring/grafana/README.md
@@ -10,6 +10,32 @@ The Grafana deployment expects a secret named `grafana-secret-env` with the foll
 | GF_AUTH_GITHUB_CLIENT_SECRET | The client secret of the GitHub app to use for auth |
 | GF_SECURITY_ADMIN_PASSWORD   | The admin password of the Grafana admin console     |
 
+Alerting expects a separate secret named `grafana-alerting-secret`:
+
+- `GF_ALERTING_DISCORD_WEBHOOK_URL`: Discord webhook for Grafana alert
+  notifications.
+
+The webhook originates from a Discord server administrator, has no scheduled
+expiration, and must be rotated in Discord if disclosed or abused. Create or
+update the Kubernetes secret out of band; never commit the webhook URL.
+
+## Provisioned alerts
+
+`alerting-staging.yaml` provisions staging-only Dragonfly alert rules and a
+staging-branded Discord contact point. Every rule filters on `cluster="staging"`
+and includes an `environment=staging` label plus a `[STAGING]` summary.
+
+The rules use the existing o11y Prometheus data source and alert on:
+
+- dead-letter growth over the rolling seven-day average;
+- failed-package growth over the rolling seven-day average;
+- queue depth that is both abnormally high and rising;
+- no package ingestion or successful scans during the preceding ten minutes.
+
+The Prometheus deployment retains one week of data, so the rolling baseline uses
+all available history. Alert rules route directly to the staging contact point
+and do not replace the instance-wide notification policy.
+
 ## Provisioned dashboards
 
 Dashboard providers and dashboard JSON are stored in

--- a/kubernetes/manifests/monitoring/grafana/alerting-staging.yaml
+++ b/kubernetes/manifests/monitoring/grafana/alerting-staging.yaml
@@ -1,0 +1,428 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: grafana-alerting-staging
+  namespace: grafana
+
+data:
+  dragonfly-staging.yaml: |-
+    apiVersion: 1
+
+    contactPoints:
+      - orgId: 1
+        name: discord-staging-alerts
+        receivers:
+          - uid: discord-staging-alerts
+            type: discord
+            disableResolveMessage: false
+            settings:
+              url: $GF_ALERTING_DISCORD_WEBHOOK_URL
+              use_discord_username: false
+              message: |
+                **VIPYR GRAFANA ALERT — STAGING**
+                {{ template "default.message" . }}
+
+    groups:
+      - orgId: 1
+        name: dragonfly-staging
+        folder: Dragonfly Alerts
+        interval: 1m
+        rules:
+          - uid: dragonfly-staging-deadletters
+            title: '[STAGING] Dead-letter growth above baseline'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_dead_lettered_total{
+                          cluster="staging",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[30m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    avg_over_time(
+                      (
+                        sum by (cluster) (
+                          increase(
+                            packages_dead_lettered_total{
+                              cluster="staging",
+                              namespace="dragonfly",
+                              container="mainframe"
+                            }[30m]
+                          )
+                        )
+                      )[7d:30m]
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 2 && $A > 3 * $B'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 5m
+            annotations:
+              summary: '[STAGING] Dead-lettering is significantly above normal'
+              description: >-
+                Staging dead-lettered {{ $values.A.Value }} packages in 30
+                minutes versus a rolling seven-day average of
+                {{ $values.B.Value }}.
+            labels:
+              environment: staging
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-staging-alerts
+
+          - uid: dragonfly-staging-failures
+            title: '[STAGING] Failed-package growth above baseline'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 900
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_fail_total{
+                          cluster="staging",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[15m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    avg_over_time(
+                      (
+                        sum by (cluster) (
+                          increase(
+                            packages_fail_total{
+                              cluster="staging",
+                              namespace="dragonfly",
+                              container="mainframe"
+                            }[15m]
+                          )
+                        )
+                      )[7d:15m]
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 10 && $A > 3 * $B'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 10m
+            annotations:
+              summary: '[STAGING] Package failures are significantly above normal'
+              description: >-
+                Staging failed {{ $values.A.Value }} packages in 15 minutes
+                versus a rolling seven-day average of {{ $values.B.Value }}.
+            labels:
+              environment: staging
+              service: dragonfly-mainframe
+              severity: warning
+            isPaused: false
+            notification_settings:
+              receiver: discord-staging-alerts
+
+          - uid: dragonfly-staging-queue-pressure
+            title: '[STAGING] Queue pressure rising above baseline'
+            condition: D
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      packages_in_queue{
+                        cluster="staging",
+                        namespace="dragonfly",
+                        container="mainframe"
+                      }
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      avg_over_time(
+                        packages_in_queue{
+                          cluster="staging",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[7d]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      packages_in_queue{
+                        cluster="staging",
+                        namespace="dragonfly",
+                        container="mainframe"
+                      } offset 30m
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: C
+              - refId: D
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - D
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 100 && $A > 3 * $B && $A - $C >= 50'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: D
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 10m
+            annotations:
+              summary: '[STAGING] Queue pressure is high and continuing to rise'
+              description: >-
+                Staging queue depth is {{ $values.A.Value }}, versus a rolling
+                seven-day average of {{ $values.B.Value }} and
+                {{ $values.C.Value }} 30 minutes ago.
+            labels:
+              environment: staging
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-staging-alerts
+
+          - uid: dragonfly-staging-no-activity
+            title: '[STAGING] No package activity'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_ingested_total{
+                          cluster="staging",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[10m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_success_total{
+                          cluster="staging",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[10m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A < 1 && $B < 1'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 2m
+            annotations:
+              summary: '[STAGING] No packages were queued or scanned successfully'
+              description: >-
+                Staging recorded {{ $values.A.Value }} ingested packages and
+                {{ $values.B.Value }} successful scans during the last 10
+                minutes.
+            labels:
+              environment: staging
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-staging-alerts

--- a/kubernetes/manifests/monitoring/grafana/deployment.yaml
+++ b/kubernetes/manifests/monitoring/grafana/deployment.yaml
@@ -56,9 +56,15 @@ spec:
                 name: grafana-default
             - secretRef:
                 name: grafana-secret-env
+            - secretRef:
+                name: grafana-alerting-secret
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-volume
+            - mountPath: /etc/grafana/provisioning/alerting/dragonfly-staging.yaml
+              name: grafana-alerting-staging
+              readOnly: true
+              subPath: dragonfly-staging.yaml
             - mountPath: /etc/grafana/provisioning/dashboards/dragonfly.yaml
               name: grafana-dashboard-provider
               readOnly: true
@@ -70,6 +76,9 @@ spec:
         - name: grafana-volume
           persistentVolumeClaim:
             claimName: grafana-storage
+        - name: grafana-alerting-staging
+          configMap:
+            name: grafana-alerting-staging
         - name: grafana-dashboard-provider
           configMap:
             name: grafana-dashboard-provider


### PR DESCRIPTION
## What changed

- Provision a staging-branded Discord contact point backed by an out-of-band Kubernetes Secret.
- Add four staging-only Dragonfly alerts for dead-letter growth, failed-package growth, rising queue pressure, and package inactivity.
- Mount the Grafana alerting provisioning file and document secret handling and thresholds.

## Why

Dragonfly needs environment-explicit operational alerts in the shared o11y
Grafana instance. All queries hard-filter `cluster="staging"`; rule names,
labels, summaries, and Discord content also identify staging.

## Impact

Grafana will load the new contact point and rule group on restart. The rules
route directly to the staging receiver without replacing the global notification
policy. The webhook value is not committed and exists only in
`grafana-alerting-secret`.

## Validation

- All PromQL queries evaluated successfully against live o11y Prometheus and returned staging-only series.
- Current values do not satisfy any alert condition.
- `kubectl apply --dry-run=server` passed for the ConfigMap and Deployment.
- All configured hooks passed on the three changed files, including `yamllint`, `markdownlint-fix`, and `ripsecrets`.
- Exact webhook identifiers were absent from the worktree.

## Baseline note

The repository-wide `prek run --all-files` remains blocked by two pre-existing
line-length errors in the recently merged embedded dashboard JSON. This PR does
not modify that dashboard file.
