### PR TITLE
Enforce single-writer Grafana rollouts

### DIFF
--- a/kubernetes/manifests/monitoring/grafana/README.md
+++ b/kubernetes/manifests/monitoring/grafana/README.md
@@ -2,6 +2,10 @@
 
 We use Grafana to display our metrics and logs from across our infrastructure.
 
+Grafana stores its SQLite database and search indexes on a single-writer
+persistent volume. The Deployment therefore uses the `Recreate` strategy so two
+Grafana processes never access those files concurrently during a rollout.
+
 The Grafana deployment expects a secret named `grafana-secret-env` with the following contents:
 
 | Environment Variable         | Description                                         |

--- a/kubernetes/manifests/monitoring/grafana/deployment.yaml
+++ b/kubernetes/manifests/monitoring/grafana/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: grafana
 
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: grafana


### PR DESCRIPTION
## What changed

- Set the Grafana Deployment strategy to `Recreate`.
- Document the SQLite, Bleve index, and single-writer PVC invariant.

## Why

The staging alert rollout exposed an existing deployment defect. Kubernetes
started a surge replica before terminating the old Grafana pod. Both processes
mounted the same persistent volume, and the new process correctly refused to
start because the Bleve index was locked.

`Recreate` terminates the old singleton before starting its replacement, matching
Grafana's current SQLite and single-writer storage architecture.

## Impact

Grafana rollouts will have a brief controlled restart instead of an unhealthy
surge replica. No data or persistent resources are changed.

## Validation

- The old Grafana replica remained healthy throughout diagnosis.
- The failing replica log identified the Bleve lock held by the old process.
- `kubectl apply --dry-run=server` passed.
- All configured hooks passed on both changed files, including `yamllint`,
  `markdownlint-fix`, and `ripsecrets`.
