### PR TITLE
Provision production Grafana alerts

### DIFF
--- a/kubernetes/manifests/monitoring/grafana/README.md
+++ b/kubernetes/manifests/monitoring/grafana/README.md
@@ -25,9 +25,10 @@ update the Kubernetes secret out of band; never commit the webhook URL.
 
 ## Provisioned alerts
 
-`alerting-staging.yaml` provisions staging-only Dragonfly alert rules and a
-staging-branded Discord contact point. Every rule filters on `cluster="staging"`
-and includes an `environment=staging` label plus a `[STAGING]` summary.
+`alerting-staging.yaml` and `alerting-prod.yaml` provision independent Dragonfly
+rule groups and environment-branded Discord contact points. Every rule filters
+on its exact `cluster` label and includes a matching `environment` label,
+summary prefix, and Discord banner.
 
 The rules use the existing o11y Prometheus data source and alert on:
 

--- a/kubernetes/manifests/monitoring/grafana/alerting-prod.yaml
+++ b/kubernetes/manifests/monitoring/grafana/alerting-prod.yaml
@@ -1,0 +1,428 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: grafana-alerting-prod
+  namespace: grafana
+
+data:
+  dragonfly-prod.yaml: |-
+    apiVersion: 1
+
+    contactPoints:
+      - orgId: 1
+        name: discord-prod-alerts
+        receivers:
+          - uid: discord-prod-alerts
+            type: discord
+            disableResolveMessage: false
+            settings:
+              url: $GF_ALERTING_DISCORD_WEBHOOK_URL
+              use_discord_username: false
+              message: |
+                **VIPYR GRAFANA ALERT — PROD**
+                {{ template "default.message" . }}
+
+    groups:
+      - orgId: 1
+        name: dragonfly-prod
+        folder: Dragonfly Alerts
+        interval: 1m
+        rules:
+          - uid: dragonfly-prod-deadletters
+            title: '[PROD] Dead-letter growth above baseline'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_dead_lettered_total{
+                          cluster="prod",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[30m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    avg_over_time(
+                      (
+                        sum by (cluster) (
+                          increase(
+                            packages_dead_lettered_total{
+                              cluster="prod",
+                              namespace="dragonfly",
+                              container="mainframe"
+                            }[30m]
+                          )
+                        )
+                      )[7d:30m]
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 2 && $A > 3 * $B'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 5m
+            annotations:
+              summary: '[PROD] Dead-lettering is significantly above normal'
+              description: >-
+                Production dead-lettered {{ $values.A.Value }} packages in 30
+                minutes versus a rolling seven-day average of
+                {{ $values.B.Value }}.
+            labels:
+              environment: prod
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-prod-alerts
+
+          - uid: dragonfly-prod-failures
+            title: '[PROD] Failed-package growth above baseline'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 900
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_fail_total{
+                          cluster="prod",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[15m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    avg_over_time(
+                      (
+                        sum by (cluster) (
+                          increase(
+                            packages_fail_total{
+                              cluster="prod",
+                              namespace="dragonfly",
+                              container="mainframe"
+                            }[15m]
+                          )
+                        )
+                      )[7d:15m]
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 10 && $A > 3 * $B'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 10m
+            annotations:
+              summary: '[PROD] Package failures are significantly above normal'
+              description: >-
+                Production failed {{ $values.A.Value }} packages in 15 minutes
+                versus a rolling seven-day average of {{ $values.B.Value }}.
+            labels:
+              environment: prod
+              service: dragonfly-mainframe
+              severity: warning
+            isPaused: false
+            notification_settings:
+              receiver: discord-prod-alerts
+
+          - uid: dragonfly-prod-queue-pressure
+            title: '[PROD] Queue pressure rising above baseline'
+            condition: D
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      packages_in_queue{
+                        cluster="prod",
+                        namespace="dragonfly",
+                        container="mainframe"
+                      }
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 604800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      avg_over_time(
+                        packages_in_queue{
+                          cluster="prod",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[7d]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    max by (cluster) (
+                      packages_in_queue{
+                        cluster="prod",
+                        namespace="dragonfly",
+                        container="mainframe"
+                      } offset 30m
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: C
+              - refId: D
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - D
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A >= 100 && $A > 3 * $B && $A - $C >= 50'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: D
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 10m
+            annotations:
+              summary: '[PROD] Queue pressure is high and continuing to rise'
+              description: >-
+                Production queue depth is {{ $values.A.Value }}, versus a rolling
+                seven-day average of {{ $values.B.Value }} and
+                {{ $values.C.Value }} 30 minutes ago.
+            labels:
+              environment: prod
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-prod-alerts
+
+          - uid: dragonfly-prod-no-activity
+            title: '[PROD] No package activity'
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_ingested_total{
+                          cluster="prod",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[10m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: bdw7z1jhaby80e
+                model:
+                  editorMode: code
+                  expr: >-
+                    sum by (cluster) (
+                      increase(
+                        packages_success_total{
+                          cluster="prod",
+                          namespace="dragonfly",
+                          container="mainframe"
+                        }[10m]
+                      )
+                    )
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  range: false
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: '$A < 1 && $B < 1'
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 2m
+            annotations:
+              summary: '[PROD] No packages were queued or scanned successfully'
+              description: >-
+                Production recorded {{ $values.A.Value }} ingested packages and
+                {{ $values.B.Value }} successful scans during the last 10
+                minutes.
+            labels:
+              environment: prod
+              service: dragonfly-mainframe
+              severity: critical
+            isPaused: false
+            notification_settings:
+              receiver: discord-prod-alerts

--- a/kubernetes/manifests/monitoring/grafana/deployment.yaml
+++ b/kubernetes/manifests/monitoring/grafana/deployment.yaml
@@ -67,6 +67,10 @@ spec:
               name: grafana-alerting-staging
               readOnly: true
               subPath: dragonfly-staging.yaml
+            - mountPath: /etc/grafana/provisioning/alerting/dragonfly-prod.yaml
+              name: grafana-alerting-prod
+              readOnly: true
+              subPath: dragonfly-prod.yaml
             - mountPath: /etc/grafana/provisioning/dashboards/dragonfly.yaml
               name: grafana-dashboard-provider
               readOnly: true
@@ -81,6 +85,9 @@ spec:
         - name: grafana-alerting-staging
           configMap:
             name: grafana-alerting-staging
+        - name: grafana-alerting-prod
+          configMap:
+            name: grafana-alerting-prod
         - name: grafana-dashboard-provider
           configMap:
             name: grafana-dashboard-provider


### PR DESCRIPTION
## What changed

- Provision a production-branded Discord contact point using the existing
  out-of-band webhook Secret.
- Add four production-only Dragonfly alerts for dead-letter growth,
  failed-package growth, rising queue pressure, and package inactivity.
- Mount the independent production provisioning file and document
  environment-specific routing.

## Why

Staging alerting is healthy and its end-to-end Discord test succeeded.
Production now needs the same indicators without any possibility of
cross-environment ambiguity in the shared o11y Grafana instance.

## Impact

All queries hard-filter `cluster="prod"`. Rule names, labels, summaries, and the
Discord banner identify production. The rules route directly to the production
receiver and do not replace the global notification policy or staging resources.

## Validation

- Production baselines were calculated independently from the retained week of
  o11y Prometheus data.
- All production PromQL queries evaluated successfully and returned only
  `cluster="prod"`.
- Current production values do not satisfy any alert condition.
- `kubectl apply --dry-run=server` passed for the ConfigMap and Deployment.
- All configured hooks passed on all changed files, including `yamllint`,
  `markdownlint-fix`, and `ripsecrets`.
- No staging identifiers or webhook values are present in the production file.
