### PR TITLE
Deploy mainframe performance hotfix

### DIFF
--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-d25c0b077d23d09016667a0942e2ac67dbb33cd0
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-faa55d9ac4900bf299c5c4597e72538f02dd5622
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

Deploy `dragonfly-mainframe` commit
`faa55d9ac4900bf299c5c4597e72538f02dd5622`.

The hotfix prevents the full-history per-rule aggregation from running in the
background and decouples historical performance snapshots from the 60-second
operational queue monitor.

## Validation

- signed image publication passed
- staging server-side dry run passed
- all hooks applicable to the changed manifest passed
- Zizmor reported no workflow findings

The repository-wide hook run also identified an unrelated pre-existing
`yamlfix`/`yamllint` conflict in the generated Grafana dashboard provisioning
manifest. That file is unchanged by this PR.

## Rollout

Apply to staging first, monitor database activity and package processing, then
apply this identical immutable image to production.
