### PR TITLE
Deploy OpenGrep shadow scanner controls to staging

### DIFF
--- a/.github/workflows/kubernetes-ci.yaml
+++ b/.github/workflows/kubernetes-ci.yaml
@@ -49,3 +49,6 @@ jobs:
           kubectl-validate kubernetes/manifests/ \
             --local-crds kubernetes/crds/ \
             --version "${KUBERNETES_VERSION}"
+          kubectl-validate kubernetes/environments/ \
+            --local-crds kubernetes/crds/ \
+            --version "${KUBERNETES_VERSION}"

--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -1,0 +1,111 @@
+# Dragonfly OpenGrep Shadow Rollout
+
+## Purpose
+
+Evaluate OpenGrep behavioral findings in staging without changing the existing
+YARA scanner, its queue, its scores, or its production alert stream.
+
+## Isolation invariants
+
+1. The YARA worker continues to use `/jobs`, `/rules`, and `/package`.
+2. The OpenGrep worker uses only `/opengrep/jobs`, `/opengrep/rules`, and
+   `/opengrep/package`.
+3. OpenGrep work and results are stored in an additive shadow table. They do
+   not update the existing `scans`, `rules`, or `package_rules` tables.
+4. OpenGrep endpoints are disabled by default. Mainframe refuses to start with
+   the feature enabled unless `ENVIRONMENT=staging`.
+5. The OpenGrep worker refuses to start unless its API origin is exactly the
+   configured staging origin.
+6. The shadow worker is a distinct DigitalOcean App Platform worker component
+   with a distinct image repository. It is added only to the existing staging
+   scanner App; no corresponding production component is introduced.
+7. OpenGrep findings have no production score. The bot publishes them as
+   staging evaluation evidence without an alert-role mention.
+
+## Staging resource inventory
+
+- DigitalOcean context: `vipyr`
+- App: `dragonfly-scanner-staging`
+- App ID: `9d243898-5b30-4ab8-a432-df4b22bd356a`
+- Existing YARA component: `scanner` (unchanged)
+- New component: `opengrep-shadow`
+- Component kind: worker
+- Component size: `apps-s-1vcpu-1gb` (1 shared vCPU, 1 GiB RAM)
+- Component count: 1
+- Image: `ghcr.io/vipyrsec/dragonfly-client-rs-opengrep-shadow` pinned
+  by immutable digest
+- Cloudflare Access application: `Mainframe`
+- Access application ID: `a252d918-8780-40d3-b44c-a66ef899d5d6`
+- Access domain: `dragonfly-staging.vipyrsec.com`
+- Access service token: `dragonfly-opengrep-shadow-staging`
+
+The worker has the following non-secret configuration:
+
+```text
+DRAGONFLY_BASE_URL=https://dragonfly-staging.vipyrsec.com
+DRAGONFLY_THREADS=1
+DRAGONFLY_BULK_SIZE=1
+```
+
+`DRAGONFLY_CF_ACCESS_CLIENT_ID` and
+`DRAGONFLY_CF_ACCESS_CLIENT_SECRET` are encrypted App Platform environment
+variables. Create a dedicated one-year Access service token and add only its
+token ID to the existing staging workload policy. Never place either
+credential value in this repository, a pull request, a shell history, a
+Kubernetes object, or deployment logs. Any temporary App spec containing the
+one-time client secret must be mode `0600`, live outside the repository, and
+be deleted immediately after App Platform accepts the update.
+
+## Deployment order
+
+1. Merge the OpenGrep corpus and service changes after required reviews pass.
+2. Publish and verify the signed staging-only OpenGrep image.
+3. Deploy the additive Mainframe database migration and updated image.
+4. Apply the staging-only ConfigMaps and restart Mainframe and the bot.
+5. Verify the existing YARA `/jobs` and `/package` flow.
+6. Create the dedicated staging Access service token and add it to the
+   existing staging workload policy.
+7. Add one `opengrep-shadow` worker to the existing staging scanner App,
+   preserving the `scanner` component byte-for-byte.
+8. Queue synthetic, known-benign, and reviewed test packages.
+9. Compare YARA duration and findings with OpenGrep duration and findings.
+10. Observe Mainframe, bot, and both App Platform worker logs for a continuous
+    five-minute period with no unanticipated errors.
+
+Only packages queued after the feature is enabled receive shadow work. The
+rollout does not backfill historical packages.
+
+## Discord delivery
+
+The bot sends one bounded summary message per completed OpenGrep scan. When
+findings exist, it creates a thread from that message and sends bounded chunks
+of finding evidence. Each chunk remains within Discord's message limit. The
+summary and thread creation are retried through the bot's existing polling
+loop; Mainframe records delivery only after the complete thread is published.
+
+## Rollback
+
+Rollback does not require dropping the additive table:
+
+1. Remove the `opengrep-shadow` component from
+   `dragonfly-scanner-staging`; do not change the existing `scanner`
+   component.
+2. Set `OPENGREP_SHADOW_ENABLED=false` on staging Mainframe and restart it.
+3. Set `DRAGONFLY_OPENGREP_SHADOW_ENABLED=false` on the staging bot and restart
+   it.
+4. Remove the shadow token from the staging Access policy and revoke it.
+5. Confirm the existing YARA client, queue status, and alert loop remain
+   healthy.
+
+Completed shadow rows remain available for offline evaluation. Queued or
+pending shadow rows are inert while the feature is disabled and may be resumed
+after re-enabling it.
+
+## Controlled performance comparison
+
+After shadow efficacy is established, the existing `scanner` and new
+`opengrep-shadow` App Platform components can be scaled independently for a
+bounded staging experiment. Pausing the YARA component does not redirect YARA
+jobs to OpenGrep, and pausing OpenGrep does not redirect shadow jobs to YARA.
+Record instance counts, component sizes, package cohort, wall-clock duration,
+and result counts for every comparison window.

--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -32,8 +32,9 @@ YARA scanner, its queue, its scores, or its production alert stream.
 - Component kind: worker
 - Component size: `apps-s-1vcpu-1gb` (1 shared vCPU, 1 GiB RAM)
 - Component count: 1
-- Image: `ghcr.io/vipyrsec/dragonfly-client-rs-opengrep-shadow` pinned
-  by immutable digest
+- Image:
+  `ghcr.io/vipyrsec/dragonfly-client-rs-opengrep-shadow@sha256:2fc392fc3cd4c8daba2117ffdb0c30d70b7c9ea5b05660951857c964e47fec11`
+- Source tag: `sha-2566bec3fd45f59d130aea75524ce5b6eeb42f22`
 - Cloudflare Access application: `Mainframe`
 - Access application ID: `a252d918-8780-40d3-b44c-a66ef899d5d6`
 - Access domain: `dragonfly-staging.vipyrsec.com`

--- a/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
+++ b/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: dragonfly-mainframe-opengrep-shadow
+  namespace: dragonfly
+
+data:
+  ENVIRONMENT: staging
+  OPENGREP_SHADOW_ENABLED: 'true'
+
+---
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: dragonfly-bot-opengrep-shadow
+  namespace: discord
+
+data:
+  DRAGONFLY_OPENGREP_SHADOW_ENABLED: 'true'

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-f04d93f7d4153555a0aa6f8b8f508df135ef52c0
+          image: ghcr.io/vipyrsec/bot:sha-53efd0a8fdd07cc94950fed02b10a30bce7b482b
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -23,6 +23,9 @@ spec:
           envFrom:
             - secretRef:
                 name: bot-env
+            - configMapRef:
+                name: dragonfly-bot-opengrep-shadow
+                optional: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kubernetes/manifests/dragonfly/mainframe/README.md
+++ b/kubernetes/manifests/dragonfly/mainframe/README.md
@@ -24,6 +24,11 @@ Staging and production must use different Access application audiences.
 same Cloudflare Zero Trust tenant; application audiences and caller service
 tokens must not be shared.
 
+The optional `dragonfly-mainframe-opengrep-shadow` ConfigMap exists only in
+the staging environment directory. Mainframe also verifies that the
+environment-specific Access audience is the staging API before enabling the
+shadow endpoints.
+
 The Ingress also expects `dragonfly/cloudflare-aop-ca` with a `ca.crt` key.
 This public CA verifies the environment-specific Cloudflare Authenticated
 Origin Pulls client certificate. Staging and production must use different

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-faa55d9ac4900bf299c5c4597e72538f02dd5622
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-dc735d9dac4ef3f8b0c19a762cf0886bf40a7a25
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -23,6 +23,9 @@ spec:
           envFrom:
             - secretRef:
                 name: dragonfly-mainframe-env
+            - configMapRef:
+                name: dragonfly-mainframe-opengrep-shadow
+                optional: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary

- add staging-only OpenGrep feature configuration for Mainframe and the Discord bot
- pin the merged Mainframe and bot images used by the shadow rollout
- validate staging environment manifests in CI
- document the isolated DigitalOcean worker, immutable signed image digest, Cloudflare Access credential handling, deployment order, rollback, and performance comparison plan

## Safety

The existing YARA scanner component and production manifests are unchanged. OpenGrep uses separate endpoints, storage, credentials, and a staging-only worker. Feature flags default off outside the staging ConfigMaps.

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --files .github/workflows/kubernetes-ci.yaml docs/dragonfly-opengrep-shadow-rollout.md kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml kubernetes/manifests/discord/bot/deployment.yaml kubernetes/manifests/dragonfly/mainframe/README.md kubernetes/manifests/dragonfly/mainframe/deployment.yaml`
- `git diff --check`

The dedicated OpenGrep image was built and signed by GitHub Actions from client commit `2566bec3fd45f59d130aea75524ce5b6eeb42f22` and is pinned by digest in the rollout record.
