### PR TITLE
Correct OpenGrep staging origin guard

### DIFF
--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -48,6 +48,13 @@ DRAGONFLY_THREADS=1
 DRAGONFLY_BULK_SIZE=1
 ```
 
+Staging Mainframe receives
+`OPENGREP_SHADOW_API_ORIGIN=https://dragonfly-staging.vipyrsec.com` from the
+staging-only ConfigMap. Its startup guard requires this exact origin while
+shadow mode is enabled. Cloudflare's Access audience remains environment
+provided through `CF_ACCESS_AUDIENCE`; its value is not embedded in
+application source.
+
 `DRAGONFLY_CF_ACCESS_CLIENT_ID` and
 `DRAGONFLY_CF_ACCESS_CLIENT_SECRET` are encrypted App Platform environment
 variables. Create a dedicated one-year Access service token and add only its

--- a/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
+++ b/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
@@ -8,6 +8,7 @@ metadata:
 
 data:
   ENVIRONMENT: staging
+  OPENGREP_SHADOW_API_ORIGIN: https://dragonfly-staging.vipyrsec.com
   OPENGREP_SHADOW_ENABLED: 'true'
 
 ---

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-dc735d9dac4ef3f8b0c19a762cf0886bf40a7a25
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-7fb5942990de80e3dba04d3db3fc782ec218a453
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- configure Mainframe's explicit OpenGrep staging API origin
- pin the signed Mainframe image containing the corrected startup guard
- document that the Cloudflare Access audience remains environment-provided and is not embedded in application source

## Root cause

The initial guard compared a Cloudflare Access audience tag to an API URL, so a correctly configured staging deployment could not start with shadow mode enabled.

## Safety

The existing YARA worker and production manifests remain unchanged. The currently running Mainframe remains on the migration-aware image with shadow mode temporarily disabled until this correction is merged and deployed.

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --files docs/dragonfly-opengrep-shadow-rollout.md kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml kubernetes/manifests/dragonfly/mainframe/deployment.yaml`
- `git diff --check`
- replacement Mainframe image build and signing workflow `30606407483` succeeded
