### PR TITLE
Pause OpenGrep shadow rollout

### DIFF
--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -5,6 +5,10 @@
 Evaluate OpenGrep behavioral findings in staging without changing the existing
 YARA scanner, its queue, its scores, or its production alert stream.
 
+The shadow pipeline is paused while alert-only queue gating is deployed. Both
+staging feature flags remain `false`, and the App Platform shadow worker remains
+absent, until the corrected Mainframe and bot images pass review.
+
 ## Isolation invariants
 
 1. The YARA worker continues to use `/jobs`, `/rules`, and `/package`.

--- a/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
+++ b/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   ENVIRONMENT: staging
   OPENGREP_SHADOW_API_ORIGIN: https://dragonfly-staging.vipyrsec.com
-  OPENGREP_SHADOW_ENABLED: 'true'
+  OPENGREP_SHADOW_ENABLED: 'false'
 
 ---
 apiVersion: v1
@@ -20,4 +20,4 @@ metadata:
   namespace: discord
 
 data:
-  DRAGONFLY_OPENGREP_SHADOW_ENABLED: 'true'
+  DRAGONFLY_OPENGREP_SHADOW_ENABLED: 'false'


### PR DESCRIPTION
## Summary

- disable the staging Mainframe OpenGrep producer flag
- disable the staging bot OpenGrep publisher flag
- document that the shadow worker is absent until alert-only gating is reviewed

## Reason

The initial prototype enqueued OpenGrep work for every ingested package. The
live staging flags and worker have already been paused. This change makes that
safe state authoritative so reconciliation cannot restore the unsafe fan-out.

## Validation

- `prek-workspace run --files docs/dragonfly-opengrep-shadow-rollout.md kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml`
- `git diff --cached --check`

The full all-files hook suite reaches an unrelated existing
`kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml` formatting
conflict: `yamlfix` changes its document separators, after which `yamllint`
reports two pre-existing long embedded JSON lines. This PR does not touch that
file; the complete hook set passes for both changed files.
