### PR TITLE
Enable alert-gated OpenGrep staging shadow

### DIFF
--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -5,44 +5,43 @@
 Evaluate OpenGrep behavioral findings in staging without changing the existing
 YARA scanner, its queue, its scores, or its production alert stream.
 
-The shadow pipeline is paused while alert-only queue gating is deployed. Both
-staging feature flags remain `false`, and the App Platform shadow worker remains
-absent, until the corrected Mainframe and bot images pass review.
+The shadow pipeline is enabled only for packages that produce a delivered,
+unsuppressed YARA alert at or above the bot's configured score threshold.
+Ordinary package ingestion does not create OpenGrep work.
 
 ## Isolation invariants
 
 1. The YARA worker continues to use `/jobs`, `/rules`, and `/package`.
 2. The OpenGrep worker uses only `/opengrep/jobs`, `/opengrep/rules`, and
    `/opengrep/package`.
-3. OpenGrep work and results are stored in an additive shadow table. They do
+3. After successfully delivering a qualifying YARA alert, the bot uses the
+   authenticated `/opengrep/alerts` endpoint to make that package eligible for
+   OpenGrep processing.
+4. OpenGrep work and results are stored in an additive shadow table. They do
    not update the existing `scans`, `rules`, or `package_rules` tables.
-4. OpenGrep endpoints are disabled by default. Mainframe refuses to start with
+5. OpenGrep endpoints are disabled by default. Mainframe refuses to start with
    the feature enabled unless `ENVIRONMENT=staging`.
-5. The OpenGrep worker refuses to start unless its API origin is exactly the
+6. The OpenGrep worker refuses to start unless its API origin is exactly the
    configured staging origin.
-6. The shadow worker is a distinct DigitalOcean App Platform worker component
+7. The shadow worker is a distinct DigitalOcean App Platform worker component
    with a distinct image repository. It is added only to the existing staging
    scanner App; no corresponding production component is introduced.
-7. OpenGrep findings have no production score. The bot publishes them as
+8. OpenGrep findings have no production score. The bot publishes them as
    staging evaluation evidence without an alert-role mention.
 
 ## Staging resource inventory
 
-- DigitalOcean context: `vipyr`
 - App: `dragonfly-scanner-staging`
-- App ID: `9d243898-5b30-4ab8-a432-df4b22bd356a`
 - Existing YARA component: `scanner` (unchanged)
 - New component: `opengrep-shadow`
 - Component kind: worker
 - Component size: `apps-s-1vcpu-1gb` (1 shared vCPU, 1 GiB RAM)
 - Component count: 1
 - Image:
-  `ghcr.io/vipyrsec/dragonfly-client-rs-opengrep-shadow@sha256:2fc392fc3cd4c8daba2117ffdb0c30d70b7c9ea5b05660951857c964e47fec11`
-- Source tag: `sha-2566bec3fd45f59d130aea75524ce5b6eeb42f22`
+  `ghcr.io/vipyrsec/dragonfly-client-rs-opengrep-shadow@sha256:475e447d0432ed143b74b0175f96cc25dfbca80a13abb34633672251517b9a24`
+- Source tag: `sha-271876f9690d6c3070fa93b3d25683e683547e68`
 - Cloudflare Access application: `Mainframe`
-- Access application ID: `a252d918-8780-40d3-b44c-a66ef899d5d6`
 - Access domain: `dragonfly-staging.vipyrsec.com`
-- Access service token: `dragonfly-opengrep-shadow-staging`
 
 The worker has the following non-secret configuration:
 
@@ -75,17 +74,20 @@ be deleted immediately after App Platform accepts the update.
 3. Deploy the additive Mainframe database migration and updated image.
 4. Apply the staging-only ConfigMaps and restart Mainframe and the bot.
 5. Verify the existing YARA `/jobs` and `/package` flow.
-6. Create the dedicated staging Access service token and add it to the
-   existing staging workload policy.
+6. Provision a dedicated staging Access service token through the provider
+   control plane and add it to the existing staging workload policy.
 7. Add one `opengrep-shadow` worker to the existing staging scanner App,
    preserving the `scanner` component byte-for-byte.
-8. Queue synthetic, known-benign, and reviewed test packages.
+8. Confirm that ordinary package ingestion creates no OpenGrep work, then use
+   a reviewed staging package that produces a qualifying YARA alert.
 9. Compare YARA duration and findings with OpenGrep duration and findings.
 10. Observe Mainframe, bot, and both App Platform worker logs for a continuous
     five-minute period with no unanticipated errors.
 
-Only packages queued after the feature is enabled receive shadow work. The
-rollout does not backfill historical packages.
+Only packages whose qualifying YARA alerts are delivered after the feature is
+enabled receive shadow work. The rollout does not backfill historical
+packages. Pre-gate shadow rows remain inert; if their package later produces a
+qualifying alert, Mainframe reinitializes that single row for a fresh scan.
 
 ## Discord delivery
 

--- a/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
+++ b/kubernetes/environments/staging/dragonfly/opengrep-shadow-config.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   ENVIRONMENT: staging
   OPENGREP_SHADOW_API_ORIGIN: https://dragonfly-staging.vipyrsec.com
-  OPENGREP_SHADOW_ENABLED: 'false'
+  OPENGREP_SHADOW_ENABLED: 'true'
 
 ---
 apiVersion: v1
@@ -20,4 +20,4 @@ metadata:
   namespace: discord
 
 data:
-  DRAGONFLY_OPENGREP_SHADOW_ENABLED: 'false'
+  DRAGONFLY_OPENGREP_SHADOW_ENABLED: 'true'

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-53efd0a8fdd07cc94950fed02b10a30bce7b482b
+          image: ghcr.io/vipyrsec/bot:sha-ac5d794421cc117a2a63b5fa2cf46b3510d2d23d
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-7fb5942990de80e3dba04d3db3fc782ec218a453
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-af5e201750602f68d51d79dd6ad0c0cc109144d7
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary

- deploy the reviewed Mainframe and bot images to staging
- enable OpenGrep only after a qualifying YARA alert is delivered
- pin the corrected, signed OpenGrep worker image in the rollout record
- remove provider-side application identifiers from the rollout document

## Safety

- ordinary package ingestion does not create OpenGrep work
- the existing YARA component and production configuration are unchanged
- no credentials, Access audiences, tenant identifiers, or provider IDs are included
- rollback remains feature-flag and worker-component removal

## Validation

- complete repository hook suite: all applicable checks passed, including ripsecrets; the existing Grafana dashboard formatter/linter conflict remains outside this diff
- all hooks passed against the exact four changed files
- Mainframe PR checks and Greptile review passed
- Mainframe image build and publish passed
- bot image build and publish passed
- OpenGrep worker image build, publish, and signing passed
