### PR TITLE
Deploy OpenGrep thread routing to staging

### DIFF
--- a/docs/dragonfly-opengrep-shadow-rollout.md
+++ b/docs/dragonfly-opengrep-shadow-rollout.md
@@ -91,11 +91,12 @@ qualifying alert, Mainframe reinitializes that single row for a fresh scan.
 
 ## Discord delivery
 
-The bot sends one bounded summary message per completed OpenGrep scan. When
-findings exist, it creates a thread from that message and sends bounded chunks
-of finding evidence. Each chunk remains within Discord's message limit. The
-summary and thread creation are retried through the bot's existing polling
-loop; Mainframe records delivery only after the complete thread is published.
+The bot replies inside the originating package-alert thread for each completed
+OpenGrep scan. Equivalent findings are grouped by rule with consolidated
+locations, and every reply remains within Discord's message limit. Thread
+creation and replies are retried through the bot's existing polling loop;
+Mainframe can replace a deleted checkpointed thread and records delivery only
+after the complete replacement thread is published.
 
 ## Rollback
 

--- a/kubernetes/manifests/discord/bot/deployment.yaml
+++ b/kubernetes/manifests/discord/bot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: bot
-          image: ghcr.io/vipyrsec/bot:sha-ac5d794421cc117a2a63b5fa2cf46b3510d2d23d
+          image: ghcr.io/vipyrsec/bot:sha-869821537d8f19d2265a97e3bcc04babec580f03@sha256:e8165bf64c8d3fa3aab531deff8d39f2b9d85a97cef64489d660fc1eb5a95917
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
+++ b/kubernetes/manifests/dragonfly/mainframe/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mainframe
-          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-af5e201750602f68d51d79dd6ad0c0cc109144d7
+          image: ghcr.io/vipyrsec/dragonfly-mainframe:sha-46e5bf72be98a8c7d69944b17eb78b026b3860ac@sha256:5c8409796b7c1291575dcdf22ba3c3751dbd5dbdb4af321536e0f7d25805dfc5
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml
+++ b/kubernetes/manifests/monitoring/grafana/dashboard-provisioning.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 apiVersion: v1
 kind: ConfigMap
 
@@ -22,6 +23,7 @@ data:
         options:
           path: /etc/grafana/dashboards/dragonfly
           foldersFromFilesStructure: false
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -761,6 +763,7 @@ data:
       "version": 1,
       "weekStart": ""
     }
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -770,7 +773,7 @@ metadata:
   namespace: grafana
 
 data:
-  rule-performance.json: |
+  rule-performance.json: |-
     {
       "annotations": {
         "list": [


### PR DESCRIPTION
## Summary

- pin the staging Discord bot and Mainframe deployments to the reviewed OpenGrep thread-routing images
- document grouped delivery in the originating alert thread and deleted-thread recovery
- make the Grafana embedded-JSON dashboard stable under both `yamlfix` and `yamllint`

## Validation

- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- bot, Mainframe, and security-intelligence source PRs merged with green CI and Greptile 5/5 reviews

## Rollback

- restore the prior bot and Mainframe image references from the preceding manifest revision
- the Mainframe database downgrade only removes the nullable experimental alert-message field
- the shadow worker image remains unchanged and continues to refresh rules by job hash
